### PR TITLE
Change placement of PLAYER_EVENT_ON_KILLED_BY_CREATURE core hook

### DIFF
--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -1182,14 +1182,6 @@ void Unit::Kill(Unit* pVictim, SpellEntry const* spellProto, bool durabilityLoss
             // durability lost message
             WorldPacket data(SMSG_DURABILITY_DAMAGE_DEATH, 0);
             pPlayerVictim->GetSession()->SendPacket(&data);
-
-            // Used by Eluna
-#ifdef ENABLE_ELUNA
-        if (Creature* killer = ToCreature())
-            {
-            sEluna->OnPlayerKilledByCreature(killer, pPlayerVictim);
-            }
-#endif /* ENABLE_ELUNA */
         }
     }
     else                                                // creature died
@@ -1274,6 +1266,15 @@ void Unit::Kill(Unit* pVictim, SpellEntry const* spellProto, bool durabilityLoss
     }
 
     pVictim->InterruptSpellsCastedOnMe(false, true);
+    
+    // Used by Eluna
+#ifdef ENABLE_ELUNA
+    if (Creature* killer = ToCreature())
+    {
+        if(pPlayerVictim)
+            sEluna->OnPlayerKilledByCreature(killer, pPlayerVictim);
+    }
+#endif /* ENABLE_ELUNA */
 }
 
 struct PetOwnerKilledUnitHelper


### PR DESCRIPTION
## 🍰 Pullrequest
Placement was missing some causes of death. Due to new placement added check to make sure that player is the unit hitting the hook not an NPC

### Proof
-User reported issue

### Issues
- None

### How2Test
User reported that prior to movement if you wrote a script like the following:

local function PlayerDeath(event, killer, killed)
    SendWorldMessage("|r Hardcore - Player: " .. killed:GetName() .. "|r got killed by Creature: " .. killer:GetName() .. "|r -  with Level:" .. killed:GetLevel() .."")
end
		
RegisterPlayerEvent(8, PlayerDeath)

and then died to ticking damage, example was given for NPC https://www.wowhead.com/wotlk/npc=3203/fizzle-darkstorm and spell casted by him https://www.wowhead.com/wotlk/spell=7290/soul-siphon and if death occurred due to this it would not fire the event. After movement and guard checks the hook now fires when death is from that damage.

### Todo / Checklist
- [X] None
